### PR TITLE
Add classed error

### DIFF
--- a/lib/cvss_suite.rb
+++ b/lib/cvss_suite.rb
@@ -12,6 +12,7 @@ require 'cvss_suite/cvss2/cvss2'
 require 'cvss_suite/cvss3/cvss3'
 require 'cvss_suite/version'
 require 'cvss_suite/helpers/extensions'
+require 'cvss_suite/errors'
 
 ##
 # Module of this gem.
@@ -24,13 +25,13 @@ module CvssSuite
 
   def self.new(vector)
     @vector_string = vector
-    case self.version
-      when 2
-        Cvss2.new(@vector_string, self.version)
-      when 3
-        Cvss3.new(@vector_string, self.version)
-      else
-        raise 'Vector is not valid!'
+    case version
+    when 2
+      Cvss2.new(@vector_string, version)
+    when 3
+      Cvss3.new(@vector_string, version)
+    else
+      raise CvssSuite::Errors::InvalidVector, 'Vector is not valid!'
     end
   end
 

--- a/lib/cvss_suite/cvss.rb
+++ b/lib/cvss_suite/cvss.rb
@@ -34,7 +34,7 @@ class Cvss
   # Raises an exception if it is called on Cvss class.
 
   def initialize(vector, version)
-    raise 'Do not instantiate this class!' if self.class == Cvss
+    raise CvssSuite::Errors::InvalidParentClass, 'Do not instantiate this class!' if self.class == Cvss
     @version = version
     @vector = vector
     @properties = []
@@ -79,7 +79,7 @@ class Cvss
   end
 
   def check_valid
-    raise 'Vector is not valid!' unless valid?
+    raise CvssSuite::Errors::InvalidVector, 'Vector is not valid!' unless valid?
   end
 
   def prepared_vector

--- a/lib/cvss_suite/errors.rb
+++ b/lib/cvss_suite/errors.rb
@@ -1,0 +1,18 @@
+module CvssSuite
+  ##
+  # This will define classed errors to be expected
+  module Errors
+    ##
+    # The base error class to be inheritted by more specific classes
+    class CvssError < StandardError
+      attr_accessor :message
+
+      def initialize(message)
+        @message = message
+      end
+    end
+
+    class InvalidVector < CvssError; end
+    class InvalidParentClass < CvssError; end
+  end
+end

--- a/spec/cvss_spec.rb
+++ b/spec/cvss_spec.rb
@@ -1,0 +1,21 @@
+# CVSS-Suite, a Ruby gem to manage the CVSS vector
+#
+# Copyright (c) Siemens AG, 2016
+#
+# Authors:
+#   Adam David <adamrdavid@gmail.com>
+#
+# This work is licensed under the terms of the MIT license.
+# See the LICENSE.md file in the top-level directory.
+
+require_relative 'spec_helper'
+
+describe Cvss do
+  context 'when initialized without subclass' do
+    subject { Cvss.new('AV:L/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:L', 2) }
+
+    it 'raises InvalidParentClass error' do
+      expect { subject }.to raise_error(CvssSuite::Errors::InvalidParentClass)
+    end
+  end
+end

--- a/spec/cvss_suite_spec.rb
+++ b/spec/cvss_suite_spec.rb
@@ -16,6 +16,7 @@ describe CvssSuite do
   end
 
   it 'is invalid' do
-    expect{CvssSuite.new('Not a valid vector!')}.to raise_error(RuntimeError, 'Vector is not valid!')
+    expect { CvssSuite.new('Not a valid vector!') }
+      .to raise_error(CvssSuite::Errors::InvalidVector, 'Vector is not valid!')
   end
 end


### PR DESCRIPTION
resolves: https://github.com/siemens/cvss-suite/issues/1

Adds custom error classes to be raised so they are easily identifiable without looking at the message of a RuntimeError (which could potentially change).

This is unfortunately a breaking change for current users and will need to bump the version.