### PR TITLE
Fix bundler restriction and remove rdoc

### DIFF
--- a/cvss_suite.gemspec
+++ b/cvss_suite.gemspec
@@ -32,9 +32,8 @@ Besides calculating the Base, Temporal and Environmental Score, you are able to 
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.10"
+  spec.add_development_dependency "bundler", ">= 1.10"
   spec.add_development_dependency "rspec", "~> 3.4"
   spec.add_development_dependency "rspec-its", "~> 1.2"
-  spec.add_development_dependency "rdoc", "~> 4.2"
   spec.add_development_dependency "simplecov", "~> 0.11.2"
 end


### PR DESCRIPTION
## Proposed changes

Fix bundler issue

```
Bundler could not find compatible versions for gem "bundler":
  In Gemfile:
    bundler (~> 1.10)

  Current Bundler version:
    bundler (2.1.2)
This Gemfile requires a different version of Bundler.
Perhaps you need to update Bundler by running `gem install bundler`?

Could not find gem 'bundler (~> 1.10)' in any of the relevant sources:
  the local ruby installation
```

## Types of changes

What types of changes does your code introduce to CvssSuite?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

