### PR TITLE
CVSSv2 Severity

### DIFF
--- a/PULL_REQUEST-cvssv2-severity.md
+++ b/PULL_REQUEST-cvssv2-severity.md
@@ -1,0 +1,24 @@
+## Proposed changes
+Severity values for CVSSv2 improperly use CVSSv3 range values.
+This pull request NVD ranges for CVSSv2 severity (https://nvd.nist.gov/vuln-metrics/cvss)
+
+## Types of changes
+
+What types of changes does your code introduce to CvssSuite?
+_Put an `x` in the boxes that apply_
+
+- [X] Bugfix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+
+## Checklist
+
+_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._
+
+- [X] Unit tests pass locally with my changes
+- [X] I have added tests that prove my fix is effective or that my feature works
+- [X] I have added necessary documentation (if appropriate)
+
+## Further comments
+
+If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

--- a/lib/cvss_suite/cvss2/cvss2.rb
+++ b/lib/cvss_suite/cvss2/cvss2.rb
@@ -23,6 +23,24 @@ module CvssSuite
       2
     end
 
+    # Returns the severity of the CVSSv2 vector.
+    # https://nvd.nist.gov/vuln-metrics/cvss
+    def severity
+      check_validity
+
+      score = overall_score
+
+      if (0.0..3.9).cover? score
+        'Low'
+      elsif (4.0..6.9).cover? score
+        'Medium'
+      elsif (7.0..10.0).cover? score
+        'High'
+      else
+        'None'
+      end
+    end
+
     ##
     # Returns the Base Score of the CVSS vector.
     def base_score

--- a/spec/cvss2/cvss2_spec.rb
+++ b/spec/cvss2/cvss2_spec.rb
@@ -48,4 +48,47 @@ describe CvssSuite::Cvss2 do
 
     it_behaves_like 'a invalid cvss vector with version', 2
   end
+
+  # Severity tests https://nvd.nist.gov/vuln-metrics/cvss
+  # v2 Severity High: 7.0 - 10.0
+  describe 'valid cvss2_severity_high' do
+    [
+      'AV:A/AC:M/Au:S/C:C/I:C/A:P', # 7.04
+      'AV:N/AC:M/Au:N/C:C/I:C/A:C', # 9.33
+      'AV:N/AC:L/Au:N/C:C/I:C/A:C'  # 9.99
+    ].each do |vector|
+      it "'#{vector}' severity is expected to eql \"High\"" do
+        cv2 = CvssSuite.new(vector)
+        expect(cv2.severity).to eq('High')
+      end
+    end
+  end
+
+
+  # v2 Severity Med: 4.0 - 6.9
+  describe 'valid cvss2_severity_med' do
+    [
+      'AV:N/AC:H/Au:N/C:N/I:P/A:P', # 4.03
+      'AV:N/AC:L/Au:M/C:P/I:P/A:P', # 5.78
+      'AV:L/AC:M/Au:N/C:C/I:C/A:C' # 6.88
+    ].each do |vector|
+      it "'#{vector}' severity is expected to eql \"Medium\"" do
+        cv2 = CvssSuite.new(vector)
+        expect(cv2.severity).to eq('Medium')
+      end
+    end
+  end
+
+  # v2 Severity Low: 0.0 - 3.9
+  describe 'valid cvss2_severity_low' do
+    [
+      'AV:L/AC:H/Au:M/C:N/I:N/A:N', # 0.0
+      'AV:L/AC:L/Au:M/C:P/I:N/A:N' # 1.44
+    ].each do |vector|
+      it "'#{vector}' severity is expected to eql \"Low\"" do
+        cv2 = CvssSuite.new(vector)
+        expect(cv2.severity).to eq('Low')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Use NVD ranges for CVSSv2 severity

## Proposed changes

Severity values for CVSSv2 currently use CVSSv3 range values.
This pull request will use NVD ranges for CVSSv2 severity (https://nvd.nist.gov/vuln-metrics/cvss)

## Types of changes

What types of changes does your code introduce to CvssSuite?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [X] Unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
